### PR TITLE
Fix role selection title in the profile creation form

### DIFF
--- a/one.lfa.android.app.timor/src/main/res/values/strings.xml
+++ b/one.lfa.android.app.timor/src/main/res/values/strings.xml
@@ -21,7 +21,7 @@
   <string name="profileAskGrade">Ó nia eskola tama iha grau ida ne\'ebé?</string>
   <string name="profileAskName">Ó naran sá?</string>
   <string name="profileAskPilotSchool"></string>
-  <string name="profileAskRole">Ó halo saida %1$s?</string>
+  <string name="profileAskRole">Ó halo saida ..?</string>
   <string name="profileCancelButton">Kansela</string>
   <string name="profileCreate">Kria</string>
   <string name="profileCreateTitle">Kria A pesoal</string>

--- a/one.lfa.android.services/src/main/res/values-lo/strings.xml
+++ b/one.lfa.android.services/src/main/res/values-lo/strings.xml
@@ -21,7 +21,7 @@
   <string name="profileAskGrade">ທ່ານສຶກສາຢູ່ຊັ້ນໃດ?</string>
   <string name="profileAskName">ຊຶ່ຂອງທ່ານແມ່ນຫຍັງ?</string>
   <string name="profileAskPilotSchool">ໂຮງຮຽນຂອງທ່ານແມ່ນໃຊ້ໂປຮແກຮມທົດລອງ elibrary ບໍ?</string>
-  <string name="profileAskRole">ທ່ານແມ່ນ %1$s?</string>
+  <string name="profileAskRole">ທ່ານແມ່ນ ..?</string>
   <string name="profileCancelButton">ຍLກເລiກ</string>
   <string name="profileCreate">ສ້າງການປຽ່ນແປງ</string>
   <string name="profileCreateTitle">ສ້າງປະຫວັດ</string>


### PR DESCRIPTION
Replace the unused string parameter in the Tetun and Laotian translations of the `profileAskRole` string with a ".." as in the English version.
![Screenshot_1614581158_edited](https://user-images.githubusercontent.com/1693076/109463166-ac67ff80-7ab8-11eb-9602-4d2e0ac24c46.png)

