### PR TITLE
Fix Open Bookshelf feed not being loaded

### DIFF
--- a/one.lfa.android.app.grande/src/main/assets/Accounts.json
+++ b/one.lfa.android.app.grande/src/main/assets/Accounts.json
@@ -60,7 +60,7 @@
     "supportsCardCreator": false,
     "supportsHelpCenter": false,
     "addAutomatically": true,
-    "catalogURI": "http://openbookshelf.dp.la/OB/groups/3",
+    "catalogURI": "https://openbookshelf.dp.la/OB/groups/3",
     "mainColor": "#ec1c24"
   },
   {

--- a/one.lfa.android.app.online/src/main/assets/Accounts.json
+++ b/one.lfa.android.app.online/src/main/assets/Accounts.json
@@ -44,7 +44,7 @@
     "supportsCardCreator": false,
     "supportsHelpCenter": false,
     "addAutomatically": true,
-    "catalogURI": "http://openbookshelf.dp.la/OB/groups/3",
+    "catalogURI": "https://openbookshelf.dp.la/OB/groups/3",
     "mainColor": "#ec1c24"
   },
   {


### PR DESCRIPTION
The Open Bookshelf feed is currently not working since the HTTP client doesn't handle redirects from HTTP to HTTPS:
>the android app is using a more modern client internally these days, so redirects are generally not a problem. the exception is when there's a redirect across protocols, because there isn't really a consistent good answer as to when that should/shouldn't be allowed. right now, the app-wide policy is to accept all redirects except for when the protocol changes

We can fix this easily by changing the endpoint that we use for the Open Bookshelf feed to use HTTPS.
Credits to @io7m for solving this.