### PR TITLE
Use the small font size as a default for new profiles

### DIFF
--- a/one.lfa.android.services/src/main/java/one/lfa/android/services/LFAProfileModificationFragment.kt
+++ b/one.lfa.android.services/src/main/java/one/lfa/android/services/LFAProfileModificationFragment.kt
@@ -471,7 +471,7 @@ class LFAProfileModificationFragment : ProfileModificationAbstractFragment() {
             isSynthesized = false
           ),
           showTestingLibraries = false,
-          readerPreferences = ReaderPreferences.builder().build(),
+          readerPreferences = ReaderPreferences.builder().setFontScale(75.0).build(),
           mostRecentAccount = null,
           hasSeenLibrarySelectionScreen = true,
           useExperimentalR2 = false


### PR DESCRIPTION
## Changes
- Modify the Profile Creation/Modification page to set the default font size for new profiles to small (75% of the standard size).