### PR TITLE
Add arrow to the feed lanes UI

### DIFF
--- a/one.lfa.android.services/src/main/res/drawable/ic_baseline_chevron_right_24.xml
+++ b/one.lfa.android.services/src/main/res/drawable/ic_baseline_chevron_right_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M10,6L8.59,7.41 13.17,12l-4.58,4.59L10,18l6,-6z"/>
+</vector>

--- a/one.lfa.android.services/src/main/res/layout/feed_lane.xml
+++ b/one.lfa.android.services/src/main/res/layout/feed_lane.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:clipChildren="false"
+  android:clipToPadding="false"
+  android:orientation="vertical">
+
+  <LinearLayout
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="16dp"
+    android:layout_marginBottom="8dp"
+    android:layout_marginLeft="16dp"
+    android:layout_marginRight="16dp"
+    android:gravity="center"
+    android:orientation="horizontal">
+
+    <TextView
+      android:id="@+id/feedLaneTitle"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginRight="8dp"
+      android:layout_weight="1"
+      android:ellipsize="end"
+      android:maxLines="1"
+      android:text="@string/catalogPlaceholder"
+      android:textColor="?attr/simplifiedColorPrimaryDark"
+      android:textSize="18sp"
+      android:textStyle="bold" />
+
+    <ImageView
+      android:src="@drawable/ic_baseline_chevron_right_24"
+      app:tint="@android:color/black"
+      android:contentDescription="@string/lfaCatalogLaneArrow"
+      android:layout_width="24dp"
+      android:layout_height="wrap_content"
+      android:layout_marginLeft="8dp"
+      android:layout_weight="0" />
+
+  </LinearLayout>
+
+  <androidx.recyclerview.widget.RecyclerView
+    android:id="@+id/feedLaneCoversScroll"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:clipChildren="false"
+    android:clipToPadding="false"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp" />
+</LinearLayout>

--- a/one.lfa.android.services/src/main/res/layout/feed_lane.xml
+++ b/one.lfa.android.services/src/main/res/layout/feed_lane.xml
@@ -7,22 +7,20 @@
   android:clipToPadding="false"
   android:orientation="vertical">
 
-  <LinearLayout
+  <RelativeLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginTop="16dp"
     android:layout_marginBottom="8dp"
     android:layout_marginLeft="16dp"
-    android:layout_marginRight="16dp"
-    android:gravity="center"
-    android:orientation="horizontal">
+    android:layout_marginRight="16dp">
 
     <TextView
       android:id="@+id/feedLaneTitle"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_marginRight="8dp"
-      android:layout_weight="1"
+      android:layout_centerVertical="true"
+      android:paddingRight="40dp"
       android:ellipsize="end"
       android:maxLines="1"
       android:text="@string/catalogPlaceholder"
@@ -35,11 +33,11 @@
       app:tint="@android:color/black"
       android:contentDescription="@string/lfaCatalogLaneArrow"
       android:layout_width="24dp"
-      android:layout_height="wrap_content"
-      android:layout_marginLeft="8dp"
-      android:layout_weight="0" />
+      android:layout_height="24dp"
+      android:layout_alignParentEnd="true"
+      android:layout_centerVertical="true" />
 
-  </LinearLayout>
+  </RelativeLayout>
 
   <androidx.recyclerview.widget.RecyclerView
     android:id="@+id/feedLaneCoversScroll"

--- a/one.lfa.android.services/src/main/res/values/strings.xml
+++ b/one.lfa.android.services/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
 <resources>
   <string name="appName">LFA</string>
   <string name="catalogBookAvailabilityLoanedIndefinite"></string>
+  <string name="lfaCatalogLaneArrow">View lane</string>
 </resources>

--- a/one.lfa.android.services/src/main/res/values/strings.xml
+++ b/one.lfa.android.services/src/main/res/values/strings.xml
@@ -3,5 +3,5 @@
 <resources>
   <string name="appName">LFA</string>
   <string name="catalogBookAvailabilityLoanedIndefinite"></string>
-  <string name="lfaCatalogLaneArrow">View lane</string>
+  <string name="lfaCatalogLaneArrow">View category</string>
 </resources>


### PR DESCRIPTION
This PR adds a custom layout that displays a right chevron on all feed lanes to show that they can be opened by tapping them.
The layout will be automatically added to all new app versions.
**Screenshot**
![device-2022-03-15-154110](https://user-images.githubusercontent.com/1693076/158307962-b999233d-c63f-447f-8ade-b263629b867b.png)

cc @ddawsonlfa @TheSunShower 

